### PR TITLE
Fix missing product parameter in product show route

### DIFF
--- a/app/Http/Controllers/Seller/DashboardController.php
+++ b/app/Http/Controllers/Seller/DashboardController.php
@@ -138,7 +138,7 @@ class DashboardController extends Controller
     public function products(Request $request)
     {
         $user = Auth::user();
-        $query = $user->products()->with(['category', 'images'])->withSoldCount();
+        $query = $user->products()->with(['category', 'images', 'reviews'])->withSoldCount();
 
         // Filter by category
         if ($request->filled('category')) {

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -166,4 +166,12 @@ class Product extends Model
             )')
         ]);
     }
+
+    /**
+     * Get the route key for the model.
+     */
+    public function getRouteKeyName()
+    {
+        return 'id';
+    }
 }


### PR DESCRIPTION
Fixes "Missing required parameter" error on seller products page by adding `getRouteKeyName()` to Product model and loading `reviews` relationship.

The error "Missing required parameter for [Route: products.show]" occurred because Laravel's route model binding couldn't correctly resolve the `product` parameter. This was fixed by explicitly defining `getRouteKeyName()` to use the 'id' field. The `reviews` relationship was also added to the seller product query to ensure all necessary data is loaded for the view.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec817975-6829-4f40-9a20-f1060d8e3f13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec817975-6829-4f40-9a20-f1060d8e3f13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

