### PR TITLE
Fix missing product parameter in product show route

### DIFF
--- a/resources/views/seller/products/edit.blade.php
+++ b/resources/views/seller/products/edit.blade.php
@@ -379,11 +379,18 @@ $sortedImages = $product->images->sortByDesc('is_primary');
             <!-- Form Actions -->
             <div class="flex flex-col sm:flex-row items-center justify-between space-y-3 sm:space-y-0">
                 <div class="flex items-center space-x-2 sm:space-x-4 w-full sm:w-auto">
+                    @if($product && $product->is_active)
                     <a href="{{ route('products.show', $product) }}"
                         class="text-blue-600 hover:text-blue-800 text-xs sm:text-sm text-center">
                         <i class="fas fa-eye mr-1"></i>
                         Pratinjau Produk
                     </a>
+                    @else
+                    <span class="text-gray-400 text-xs sm:text-sm text-center cursor-not-allowed">
+                        <i class="fas fa-eye mr-1"></i>
+                        Pratinjau Produk (Tidak Aktif)
+                    </span>
+                    @endif
                 </div>
                 <div
                     class="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-4 w-full sm:w-auto">

--- a/resources/views/seller/products/index.blade.php
+++ b/resources/views/seller/products/index.blade.php
@@ -191,10 +191,16 @@
 
             <div class="flex flex-col gap-2 mt-2">
                 <div class="flex gap-2 w-full">
+                    @if($product && $product->is_active)
                     <a href="{{ route('products.show', $product) }}"
                         class="flex-1 bg-gray-100 text-gray-700 px-2 py-1.5 rounded text-xs font-medium hover:bg-gray-200 text-center">
                         Lihat
                     </a>
+                    @else
+                    <span class="flex-1 bg-gray-100 text-gray-400 px-2 py-1.5 rounded text-xs font-medium text-center cursor-not-allowed">
+                        Lihat
+                    </span>
+                    @endif
                     <a href="{{ route('seller.products.edit', $product) }}"
                         class="flex-1 {{ !$product->is_active ? 'bg-gray-400 text-gray-200 hover:bg-gray-500' : 'bg-blue-600 text-white hover:bg-blue-700' }} px-2 py-1.5 rounded text-xs font-medium text-center">
                         Edit

--- a/resources/views/seller/products/index.blade.php
+++ b/resources/views/seller/products/index.blade.php
@@ -105,11 +105,12 @@
         @if($products->count() > 0)
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-6 gap-6">
             @foreach($products as $product)
+            @if($product)
             <div
-                class="bg-white shadow rounded-lg overflow-hidden hover:shadow-lg transition-shadow flex flex-col h-full {{ !$product->is_active ? 'opacity-75' : '' }}">
+                class="bg-white shadow rounded-lg overflow-hidden hover:shadow-lg transition-shadow flex flex-col h-full {{ !($product->is_active ?? false) ? 'opacity-75' : '' }}">
                 <!-- Product Image -->
                 <div class="relative aspect-w-1 aspect-h-1 bg-gray-200">
-                    @if($product->primaryImage)
+                    @if($product->primaryImage && $product->primaryImage->image)
                     <img src="{{ url('storage/'.$product->primaryImage->image) }}" alt="{{ $product->productname }}"
                         class="w-full h-36 object-cover">
                     @else
@@ -117,22 +118,22 @@
                         <i class="fas fa-image text-gray-400 text-2xl"></i>
                     </div>
                     @endif
-                    @if(!$product->is_active)
+                    @if(!($product->is_active ?? false))
                     <div class="absolute inset-0 bg-gray-900 bg-opacity-20"></div>
                     @endif
                     <!-- Status Badge -->
                     <div class="absolute top-2 left-2">
                         <span
-                            class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium {{ $product->is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
-                            {{ $product->is_active ? 'Aktif' : 'Tidak Aktif' }}
+                                                    class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium {{ ($product->is_active ?? false) ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
+                        {{ ($product->is_active ?? false) ? 'Aktif' : 'Tidak Aktif' }}
                         </span>
                     </div>
                     <!-- Stock Badge -->
-                    @if($product->productstock <= 0) <div
+                    @if(($product->productstock ?? 0) <= 0) <div
                         class="absolute top-2 right-2 bg-red-600 text-white text-xs px-2 py-1 rounded">
                         Habis
                 </div>
-                @elseif($product->productstock <= 10) <div
+                @elseif(($product->productstock ?? 0) <= 10) <div
                     class="absolute top-2 right-2 bg-yellow-600 text-white text-xs px-2 py-1 rounded">
                     Stok Terbatas
             </div>
@@ -143,15 +144,15 @@
         <div class="flex flex-col flex-1 justify-between p-3">
             <div>
                 <h3 class="text-sm font-semibold text-gray-900 mb-1 line-clamp-2 min-h-[2.5rem]">
-                    {{ $product->productname }}
-                    @if(!$product->is_active)
+                    {{ $product->productname ?? 'Nama produk tidak tersedia' }}
+                    @if(!($product->is_active ?? false))
                     <span class="text-xs text-red-500 font-normal">(Tidak Aktif)</span>
                     @endif
                 </h3>
-                <p class="text-xs text-gray-600 mb-1">{{ $product->category->category }}</p>
+                <p class="text-xs text-gray-600 mb-1">{{ $product->category->category ?? 'Kategori tidak tersedia' }}</p>
                 <p class="text-xs text-gray-500 mb-2 line-clamp-2 min-h-[2rem]">
                     @php
-                    $desc = strip_tags($product->productdescription);
+                    $desc = strip_tags($product->productdescription ?? 'Deskripsi tidak tersedia');
                     $words = explode(' ', $desc);
                     if(count($words) > 15) {
                     $desc = implode(' ', array_slice($words, 0, 15)) . '...';
@@ -161,15 +162,15 @@
                 </p>
                 <div class="mb-2">
                     <span class="text-sm font-bold text-blue-600">
-                        Rp {{ number_format($product->productprice) }}
+                        Rp {{ number_format($product->productprice ?? 0) }}
                     </span>
                 </div>
                 <!-- Rating and Sales -->
                 <div class="flex items-center justify-between mb-2">
                     <div class="flex items-center">
                         @php
-                        $avgRating = $product->reviews->avg('rating') ?? 0;
-                        $reviewsCount = $product->reviews->count();
+                        $avgRating = $product->reviews ? $product->reviews->avg('rating') ?? 0 : 0;
+                        $reviewsCount = $product->reviews ? $product->reviews->count() : 0;
                         @endphp
                         <div class="flex items-center">
                             @for($i = 1; $i <= 5; $i++) <i
@@ -185,13 +186,13 @@
                 </div>
                 <!-- Stock Info -->
                 <div class="text-xs text-gray-500 mb-2">
-                    Stok: {{ $product->productstock }} • {{ $product->images->count() }} gambar
+                    Stok: {{ $product->productstock ?? 0 }} • {{ $product->images ? $product->images->count() : 0 }} gambar
                 </div>
             </div>
 
             <div class="flex flex-col gap-2 mt-2">
                 <div class="flex gap-2 w-full">
-                    @if($product && $product->is_active)
+                    @if($product && ($product->is_active ?? false))
                     <a href="{{ route('products.show', $product) }}"
                         class="flex-1 bg-gray-100 text-gray-700 px-2 py-1.5 rounded text-xs font-medium hover:bg-gray-200 text-center">
                         Lihat
@@ -201,14 +202,21 @@
                         Lihat
                     </span>
                     @endif
+                    @if($product)
                     <a href="{{ route('seller.products.edit', $product) }}"
-                        class="flex-1 {{ !$product->is_active ? 'bg-gray-400 text-gray-200 hover:bg-gray-500' : 'bg-blue-600 text-white hover:bg-blue-700' }} px-2 py-1.5 rounded text-xs font-medium text-center">
+                        class="flex-1 {{ !($product->is_active ?? false) ? 'bg-gray-400 text-gray-200 hover:bg-gray-500' : 'bg-blue-600 text-white hover:bg-blue-700' }} px-2 py-1.5 rounded text-xs font-medium text-center">
                         Edit
                     </a>
+                    @else
+                    <span class="flex-1 bg-gray-400 text-gray-200 px-2 py-1.5 rounded text-xs font-medium text-center cursor-not-allowed">
+                        Edit
+                    </span>
+                    @endif
                 </div>
             </div>
         </div>
     </div>
+    @endif
     @endforeach
 </div>
 </div>


### PR DESCRIPTION
Add null and active status checks to product view links in seller dashboards to resolve 'Missing required parameter' errors.

The 'Missing required parameter for [Route: products.show]' error occurred when `$product` was null or inactive, causing broken links. This PR ensures the link is only generated for valid, active products, improving user experience by showing a disabled button for inactive products instead of a broken link.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fbe3fb5-9585-49b2-a550-9b29d45187d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fbe3fb5-9585-49b2-a550-9b29d45187d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

